### PR TITLE
Implement 'at' method for RubyArray

### DIFF
--- a/src/runtime/array.ts
+++ b/src/runtime/array.ts
@@ -480,6 +480,25 @@ export const init = () => {
 
             return deleted_element;
         });
+        
+        klass.define_native_method("at", async (self: RValue, args: RValue[]): Promise<RValue> => {
+    const elements = self.get_data<RubyArray>().elements;
+    const [index_arg] = await Args.scan("1", args);
+
+    await Runtime.assert_type(index_arg, await Integer.klass());
+    let index = index_arg.get_data<number>();
+
+    // wraparound
+    if (index < 0) {
+        index = elements.length + index;
+    }
+
+    if (index < 0 || index >= elements.length) {
+        return Qnil;
+    }
+
+    return elements[index];
+});
 
         klass.define_native_method("[]", async (self: RValue, args: RValue[], _kwargs?: Hash, block?: RValue): Promise<RValue> => {
             const elements = self.get_data<RubyArray>().elements;


### PR DESCRIPTION
Add 'at' method to RubyArray for element retrieval by index.Adds support for Array#at(index).

- Supports negative indexes
- Returns nil for out-of-range indexes
- Reuses the same lookup behavior as Array#[]

Fixes #35