### PR TITLE
Implement Kernel#p

### DIFF
--- a/src/runtime/kernel.ts
+++ b/src/runtime/kernel.ts
@@ -877,6 +877,24 @@ export const init = async () => {
         return await sprintf(args[0], args.slice(1));
     });
 
+    mod.define_native_method("p", async (_self: RValue, args: RValue[]): Promise<RValue> => {
+        if (args.length === 0) {
+            return Qnil;
+        }
+
+        const stdout = ExecutionContext.current.globals["$stdout"];
+        for (const arg of args) {
+            const inspect_str = (await Object.send(arg, "inspect")).get_data<string>();
+            await Object.send(stdout, "write", [await RubyString.new(inspect_str + "\n")]);
+        }
+
+        if (args.length === 1) {
+            return args[0];
+        }
+
+        return await RubyArray.new(args);
+    }, Visibility.private);
+
     mod.define_native_method("warn", async (self: RValue, args: RValue[], kwargs?: Hash): Promise<RValue> => {
         let uplevel = 0;
         const uplevel_rval = await Args.get_kwarg("uplevel", kwargs);


### PR DESCRIPTION
### 👋

Had a lot of fun working on #3  and doing hand coding for the first time in a while. I did use Claude Code with Fable as a learning partner to get up to speed on the overall codebase, patterns, and styles, but I wrote and made all the syntax mistakes on my own in Neovim.

### 🔧 Implementation Notes

I did a few things worth mentioning in case it's not exactly idiomatic for this project. I had an early return for when no args get passed in and I stored off a reference to `stdout` outside the loop around arguments. I'm super open to making any changes if it could be done better or more idiomatically.

### 🧪 Spec Coverage

I noticed there was this line at the end of the spec which made me wonder about the coverage for `Kernel#p`:
```
describe "Kernel.p" do
  it "needs to be reviewed for spec completeness"
end
```

When I had Claude check against the ruby spec to see if it had more it noticed that after checking [ruby/spec](https://github.com/ruby/spec) that MRI had only these tests for `Kernel#p`, so I may shoot of a small PR to add a few upstream. 