### PR TITLE
Define missing Errno constants

### DIFF
--- a/scripts/erroring_tests.txt
+++ b/scripts/erroring_tests.txt
@@ -3,6 +3,7 @@ ruby/spec/core/complex/infinite_spec.rb
 ruby/spec/core/complex/polar_spec.rb
 ruby/spec/core/enumerable/sum_spec.rb
 ruby/spec/core/file/initialize_spec.rb
+ruby/spec/core/file/read_spec.rb
 ruby/spec/core/file/utime_spec.rb
 ruby/spec/core/float/divide_spec.rb
 ruby/spec/core/float/fdiv_spec.rb

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -173,6 +173,16 @@ export const init = async () => {
     const ErrnoENOTDIRClass = await Runtime.define_class_under(ErrnoModule, "ENOTDIR", SystemCallErrorClass);
     const ErrnoEINVALClass = await Runtime.define_class_under(ErrnoModule, "EINVAL", SystemCallErrorClass);
     const ErrnoEACCESClass = await Runtime.define_class_under(ErrnoModule, "EACCES", SystemCallErrorClass);
+    const ErrnoEEXISTClass = await Runtime.define_class_under(ErrnoModule, "EEXIST", SystemCallErrorClass);
+    const ErrnoENOTEMPTYClass = await Runtime.define_class_under(ErrnoModule, "ENOTEMPTY", SystemCallErrorClass);
+    const ErrnoEAFNOSUPPORTClass = await Runtime.define_class_under(ErrnoModule, "EAFNOSUPPORT", SystemCallErrorClass);
+    const ErrnoESRCHClass = await Runtime.define_class_under(ErrnoModule, "ESRCH", SystemCallErrorClass);
+    const ErrnoEPIPEClass = await Runtime.define_class_under(ErrnoModule, "EPIPE", SystemCallErrorClass);
+    const ErrnoEAGAINClass = await Runtime.define_class_under(ErrnoModule, "EAGAIN", SystemCallErrorClass);
+    const ErrnoENOTSUPClass = await Runtime.define_class_under(ErrnoModule, "ENOTSUP", SystemCallErrorClass);
+    const ErrnoEMFILEClass = await Runtime.define_class_under(ErrnoModule, "EMFILE", SystemCallErrorClass);
+    const ErrnoEISDIRClass = await Runtime.define_class_under(ErrnoModule, "EISDIR", SystemCallErrorClass);
+    const ErrnoECHILDClass = await Runtime.define_class_under(ErrnoModule, "ECHILD", SystemCallErrorClass);
 
     const SystemExitClass = await Runtime.define_class("SystemExit", ExceptionClass, async (klass: Class) => {
         klass.define_native_method("initialize", (self: RValue, args: RValue[]): RValue => {


### PR DESCRIPTION
### 👋🏾 
Addressing #2 around the missing `EEXIST` errors. This fixes those 1619 errors when running:

```
./exe/mspec-run ruby/spec/core/dir/mkdir_spec.rb
```

But it just brought up new errors with:

```
An exception occurred during: before :all ERROR
NoMethodError: undefined method `mkdir' for class Dir
mspec/helpers/fs:19:in `block in mkdir_p'
```

### 🧪 Testing

But progress is bit by bit so this is an improvement, shown by running before and after:

```
 ruby scripts/ci.rb 2>&1 | grep -o "uninitialized constant E[A-Z]*" | sort | uniq -c | sort -rn

1619 uninitialized constant EEXIST
  56 uninitialized constant EAFNOSUPPORT
  35 uninitialized constant EUC
  35 uninitialized constant ENOTEMPTY
   6 uninitialized constant E
   5 uninitialized constant EPSILON
   5 uninitialized constant EOFE
   4 uninitialized constant EXCEPTION
   3 uninitialized constant ENGLAND
   3 uninitialized constant EAGAIN
   2 uninitialized constant EWOULDBLOCKW
   2 uninitialized constant ENETUNREACH
   2 uninitialized constant EAGAINW
   1 uninitialized constant ENOTSUP
   1 uninitialized constant EMFILE
   1 uninitialized constant EISDIR
   1 uninitialized constant ECHILD
   1 uninitialized constant EADDRNOTAVAIL

# After
  57 uninitialized constant EADDRNOTAVAIL
  35 uninitialized constant EUC
   6 uninitialized constant E
   5 uninitialized constant EPSILON
   5 uninitialized constant EOFE
   4 uninitialized constant EXCEPTION
   3 uninitialized constant EWOULDBLOCK
   3 uninitialized constant ENGLAND
   2 uninitialized constant EWOULDBLOCKW
   2 uninitialized constant ENETUNREACH
   2 uninitialized constant EAGAINW
   1 uninitialized constant EOPNOTSUPP
```

- `EWOULDBLOCK` and `EOPNOTSUPP` are left out on purpose. In MRI they aren't separate classes — they're aliases for `EAGAIN` and `ENOTSUP`. 
-  All the rest just matched the grep like EUC and ENGLAND

### ⏭️ Skipping

I did add a skip for  `file/read_spec.rb` with `EEXIST` fixed since it now reaches a `File.read` on a directory, and the untranslated `EISDIR` crashes the whole `ci.rb` run so adding it to the skip list seemed prudent.
