### PR TITLE
Make a couple README.md bash snippets more copy/paste friendly

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,11 @@ Run the Jest tests by executing:
 
 ```bash
 npm run test
+```
 
-# or in docker like so:
+Or, in docker like so:
+
+```bash
 exe/dev npm run test
 ```
 
@@ -100,8 +103,11 @@ Currently, paths to test files must be provided (i.e. running the whole test sui
 
 ```bash
 exe/mspec-run ruby/spec/core/array/clear_spec.rb
+```
 
-# or in docker like so:
+Or, in docker like so:
+
+```bash
 exe/dev mspec-run ruby/spec/core/array/clear_spec.rb
 ```
 


### PR DESCRIPTION
I had submitted this as PR https://github.com/camertron/garnet-js/pull/59 but then accidentally closed it indirectly when moving some branches around in my fork.

> I noticed using the copy/paste icon is a bit awkward when the docker/non-docker commands are combined in the same fence posts. So just broke them out as an excuse to open a PR!
> 
> Cheers!