### PR TITLE
Add GitHub Actions workflow to run `typecheck` and `test` in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,26 @@
+name: Build
+
+on:
+  push:
+    branches: ["main"]
+
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .tool-versions
+          cache: npm
+
+      - run: npm ci
+      - run: npm run typecheck
+      - run: npm run test


### PR DESCRIPTION
I noticed the repo doesn't have a GitHub Actions workflow to make sure it passes the typecheck and tests.

Currently `typecheck` is failing on main.