### PR TITLE
Fix `String#insert`

### DIFF
--- a/src/__tests__/string-insert.test.ts
+++ b/src/__tests__/string-insert.test.ts
@@ -1,0 +1,80 @@
+import {beforeAll, describe, expect, test} from '@jest/globals';
+import * as Garnet from "../garnet";
+import { evaluate } from '../test_helpers';
+import { FrozenError, IndexError, TypeError as RubyTypeError } from '../errors';
+
+beforeAll(() => {
+    return Garnet.init();
+});
+
+afterAll(() => {
+    return Garnet.deinit();
+});
+
+describe("String#insert", () => {
+    test("inserts before the character at the given index", async () => {
+        expect((await evaluate("'hello'.insert(2, 'XX')")).get_data<string>()).toEqual("heXXllo");
+        expect((await evaluate("'abcd'.insert(1, 'X')")).get_data<string>()).toEqual("aXbcd");
+    });
+
+    test("prepends at index 0 and appends at the end", async () => {
+        expect((await evaluate("'abcd'.insert(0, 'X')")).get_data<string>()).toEqual("Xabcd");
+        expect((await evaluate("'abcd'.insert(4, 'X')")).get_data<string>()).toEqual("abcdX");
+        expect((await evaluate("''.insert(0, 'X')")).get_data<string>()).toEqual("X");
+    });
+
+    test("counts negative indices back from the end", async () => {
+        expect((await evaluate("'abcd'.insert(-3, 'X')")).get_data<string>()).toEqual("abXcd");
+        expect((await evaluate("'abcd'.insert(-5, 'X')")).get_data<string>()).toEqual("Xabcd");
+    });
+
+    test("appends when the index is -1", async () => {
+        expect((await evaluate("'abcd'.insert(-1, 'X')")).get_data<string>()).toEqual("abcdX");
+        expect((await evaluate("''.insert(-1, 'X')")).get_data<string>()).toEqual("X");
+    });
+
+    test("inserts by character rather than by byte", async () => {
+        expect((await evaluate("'日本語'.insert(1, 'X')")).get_data<string>()).toEqual("日X本語");
+        expect((await evaluate("'日本語'.insert(-1, 'X')")).get_data<string>()).toEqual("日本語X");
+    });
+
+    test("mutates and returns the receiver", async () => {
+        expect((await evaluate("s = +'abc'; s.insert(1, 'X').equal?(s)")).get_data<boolean>()).toEqual(true);
+        expect((await evaluate("s = +'abc'; s.insert(1, s)")).get_data<string>()).toEqual("aabcbc");
+    });
+
+    test("raises an IndexError when the index is out of range", async () => {
+        await expect(async () => await evaluate("'abcd'.insert(5, 'X')")).rejects.toThrow(IndexError);
+        await expect(async () => await evaluate("'abcd'.insert(5, 'X')")).rejects.toThrow("index 5 out of string");
+    });
+
+    test("reports the incremented index when a negative index is out of range", async () => {
+        await expect(async () => await evaluate("'abcd'.insert(-6, 'X')")).rejects.toThrow("index -5 out of string");
+    });
+
+    test("raises a FrozenError, but only once the index is known to be in range", async () => {
+        await expect(async () => await evaluate("'abcd'.freeze.insert(1, 'X')")).rejects.toThrow(FrozenError);
+        await expect(async () => await evaluate("'abcd'.freeze.insert(99, 'X')")).rejects.toThrow(IndexError);
+    });
+
+    test("converts its arguments with to_int and to_str", async () => {
+        expect((await evaluate("o = Object.new; def o.to_int; 1; end; 'abcd'.insert(o, 'X')")).get_data<string>()).toEqual("aXbcd");
+        expect((await evaluate("o = Object.new; def o.to_str; 'Z'; end; 'abcd'.insert(1, o)")).get_data<string>()).toEqual("aZbcd");
+    });
+
+    test("raises a TypeError when its arguments cannot be converted", async () => {
+        await expect(async () => await evaluate("'abcd'.insert(1, 42)")).rejects.toThrow(RubyTypeError);
+        await expect(async () => await evaluate("'abcd'.insert(1, 42)")).rejects.toThrow("no implicit conversion of Integer into String");
+        await expect(async () => await evaluate("'abcd'.insert('1', 'X')")).rejects.toThrow("no implicit conversion of String into Integer");
+    });
+
+    test("converts the index before the string, and both before any other check", async () => {
+        await expect(async () => await evaluate("'abcd'.insert('1', 42)")).rejects.toThrow("no implicit conversion of String into Integer");
+        await expect(async () => await evaluate("'abcd'.insert(99, 42)")).rejects.toThrow("no implicit conversion of Integer into String");
+        await expect(async () => await evaluate("'abcd'.freeze.insert(1, 42)")).rejects.toThrow("no implicit conversion of Integer into String");
+    });
+
+    test("raises an ArgumentError unless given two arguments", async () => {
+        await expect(async () => await evaluate("'abcd'.insert(1)")).rejects.toThrow("wrong number of arguments (given 1, expected 2)");
+    });
+});

--- a/src/runtime/string.ts
+++ b/src/runtime/string.ts
@@ -947,31 +947,37 @@ export const init = async () => {
         });
 
         klass.define_native_method("insert", async (self: RValue, args: RValue[]): Promise<RValue> => {
-            const self_data = self.get_data<string>();
             // raises unless two (required) positional args are given
             let [index_rval, other_rval] = await Args.scan("2", args);
-            other_rval = await Runtime.coerce_to_string(other);
-            const other = other_rval.get_data<string>();
 
-            index_rval = await Runtime.coerce_to_int(index_rval)
+            index_rval = await Runtime.coerce_to_int(index_rval);
+            other_rval = await Runtime.coerce_to_string(other_rval);
+
+            const self_data = self.get_data<string>();
+            const other_data = other_rval.get_data<string>();
             let index = index_rval.get_data<number>();
-            if (index < 0 ) index = self_data.length + 1 + index;
 
-            if (index > self_data.length || index < 0) {
+            if (index === -1) {
+                index = self_data.length;
+            } else if (index < 0) {
+                index ++;
+
+                if (-index > self_data.length) {
+                    throw new IndexError(`index ${index} out of string`);
+                }
+
+                index += self_data.length;
+            }
+
+            if (index > self_data.length) {
                 throw new IndexError(`index ${index} out of string`);
             }
 
             await RubyObject.check_frozen(self);
 
-            if (index == 0) {
-                self.data = other_data + self_data;
-            } else if (index === self_data.length) {
-                await append_to(self, other);
-            } else {
-                const left = self_data.substring(0, index);
-                const right = self_data.substring(index);
-                self.data = left + other_data + right;
-            }
+            const left = self_data.substring(0, index);
+            const right = self_data.substring(index);
+            self.data = left + other_data + right;
 
             return self;
         });


### PR DESCRIPTION
This pull request fixes `String#insert`, which does not currently compile and raises a `NativeError` at runtime for every input:

```ruby
"hello".insert(2, "XX")
# NativeError: Cannot access 'other' before initialization
```

The method was introduced in #61 with a half finished rename still in it. It reads `other` a line before that variable is declared, and then refers twice to an `other_data` that never exists:

```ts
other_rval = await Runtime.coerce_to_string(other);  // `other` is declared on the next line
const other = other_rval.get_data<string>();
...
self.data = other_data + self_data;                  // `other_data` is not defined anywhere
await append_to(self, other);                        // `other` is a string, `append_to` takes an RValue
```

The suite has failing, which is also why `typecheck` is currently red on `main` as noted in #64.

Naming the converted string `other_data` and passing `other_rval` to the conversion resolves all six. Fixing the compile errors alone still leaves behavior that MRI does not share, so the index handling is reworked to match. 

With this applied, `npm run typecheck` is clean and the test suite passes again.

Enables #64, which cannot go green until this lands.